### PR TITLE
chore: scaffold e-commerce monorepo skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+coverage
+.env

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# medium_high_traffic_e_commerce
+# E-commerce Monorepo
 
-git push -u origin main
-dev
+Monorepo skeleton for a microservice-based e-commerce platform built with Next.js and NestJS.
+
+## Structure
+
+- `apps/` – application services (frontend and backend)
+- `packages/` – shared TypeScript packages
+- `tools/` – helper scripts
+- `infra/` – infrastructure configuration

--- a/apps/api-gateway/package.json
+++ b/apps/api-gateway/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@ecommerce/api-gateway",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "ts-node src/main.ts",
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.2.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/apps/api-gateway/src/app.module.ts
+++ b/apps/api-gateway/src/app.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}

--- a/apps/api-gateway/src/main.ts
+++ b/apps/api-gateway/src/main.ts
@@ -1,0 +1,9 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/apps/api-gateway/tsconfig.json
+++ b/apps/api-gateway/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/client/next-env.d.ts
+++ b/apps/client/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/apps/client/next.config.js
+++ b/apps/client/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@ecommerce/client",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/apps/client/pages/index.tsx
+++ b/apps/client/pages/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const HomePage: React.FC = () => {
+  return <div>Welcome to E-commerce</div>;
+};
+
+export default HomePage;

--- a/apps/client/tsconfig.json
+++ b/apps/client/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "lib": ["dom", "dom.iterable", "esnext"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/apps/orders/package.json
+++ b/apps/orders/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@ecommerce/orders",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "ts-node src/main.ts",
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.2.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/apps/orders/src/app.module.ts
+++ b/apps/orders/src/app.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}

--- a/apps/orders/src/main.ts
+++ b/apps/orders/src/main.ts
@@ -1,0 +1,9 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/apps/orders/tsconfig.json
+++ b/apps/orders/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/payments/package.json
+++ b/apps/payments/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@ecommerce/payments",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "ts-node src/main.ts",
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.2.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/apps/payments/src/app.module.ts
+++ b/apps/payments/src/app.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}

--- a/apps/payments/src/main.ts
+++ b/apps/payments/src/main.ts
@@ -1,0 +1,9 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/apps/payments/tsconfig.json
+++ b/apps/payments/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/products/package.json
+++ b/apps/products/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@ecommerce/products",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "ts-node src/main.ts",
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.2.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/apps/products/src/app.module.ts
+++ b/apps/products/src/app.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}

--- a/apps/products/src/main.ts
+++ b/apps/products/src/main.ts
@@ -1,0 +1,9 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/apps/products/tsconfig.json
+++ b/apps/products/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/search/package.json
+++ b/apps/search/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@ecommerce/search",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "ts-node src/main.ts",
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.2.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/apps/search/src/app.module.ts
+++ b/apps/search/src/app.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}

--- a/apps/search/src/main.ts
+++ b/apps/search/src/main.ts
@@ -1,0 +1,9 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/apps/search/tsconfig.json
+++ b/apps/search/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/users/package.json
+++ b/apps/users/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@ecommerce/users",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "ts-node src/main.ts",
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.2.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/apps/users/src/app.module.ts
+++ b/apps/users/src/app.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}

--- a/apps/users/src/main.ts
+++ b/apps/users/src/main.ts
@@ -1,0 +1,9 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/apps/users/tsconfig.json
+++ b/apps/users/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "include": ["src/**/*"]
+}

--- a/infra/docker/README.md
+++ b/infra/docker/README.md
@@ -1,0 +1,3 @@
+# Dockerfiles
+
+Service Dockerfiles for container builds.

--- a/infra/grafana-dashboards/README.md
+++ b/infra/grafana-dashboards/README.md
@@ -1,0 +1,3 @@
+# Grafana Dashboards
+
+Dashboards for monitoring services.

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -1,0 +1,3 @@
+# Kubernetes Manifests
+
+Helm charts or Kustomize configs for deploying services.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ecommerce-monorepo",
+  "private": true,
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "dev": "echo 'dev script not implemented'",
+    "build": "echo 'build not implemented'",
+    "test": "echo 'no tests'"
+  }
+}

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['eslint:recommended'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+};

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@ecommerce/eslint-config",
+  "version": "0.0.1",
+  "private": true,
+  "main": "index.js",
+  "peerDependencies": {
+    "eslint": ">=8"
+  }
+}

--- a/packages/openapi-client/package.json
+++ b/packages/openapi-client/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@ecommerce/openapi-client",
+  "version": "0.0.1",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  }
+}

--- a/packages/openapi-client/src/index.ts
+++ b/packages/openapi-client/src/index.ts
@@ -1,0 +1,2 @@
+// Placeholder for generated OpenAPI client
+export const placeholder = true;

--- a/packages/openapi-client/tsconfig.json
+++ b/packages/openapi-client/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@ecommerce/shared-types",
+  "version": "0.0.1",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  }
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1,0 +1,4 @@
+export interface User {
+  id: string;
+  email: string;
+}

--- a/packages/shared-types/tsconfig.json
+++ b/packages/shared-types/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/shared-utils/package.json
+++ b/packages/shared-utils/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@ecommerce/shared-utils",
+  "version": "0.0.1",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  }
+}

--- a/packages/shared-utils/src/index.ts
+++ b/packages/shared-utils/src/index.ts
@@ -1,0 +1,4 @@
+export const logger = (msg: string): void => {
+  // eslint-disable-next-line no-console
+  console.log(msg);
+};

--- a/packages/shared-utils/tsconfig.json
+++ b/packages/shared-utils/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,3 @@
+# Tools
+
+Utility scripts for code generation, database, and CI helpers.

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": "."
+  }
+}


### PR DESCRIPTION
## Summary
- initialize root npm workspace and base tsconfig
- scaffold Next.js client app
- add NestJS API gateway and service skeletons for users, products, orders, payments, and search
- introduce shared utility/type packages and infra placeholders

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a88e20c124832c9e841eb2bfb58890