### PR TITLE
feat: add kafka event bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pnpm install
 ```
 
 ## Development
-Start the database and all services:
+Start the database, Kafka, and all services:
 
 ```bash
 docker compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,29 +10,61 @@ services:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
   users:
     build: ./services/users
     ports:
       - "3001:3000"
     depends_on:
       - postgres
+      - kafka
+    environment:
+      KAFKA_BROKER: kafka:9092
   orders:
     build: ./services/orders
     ports:
       - "3002:3000"
     depends_on:
       - postgres
+      - kafka
+    environment:
+      KAFKA_BROKER: kafka:9092
   payments:
     build: ./services/payments
     ports:
       - "3003:3000"
     depends_on:
       - postgres
+      - kafka
+    environment:
+      KAFKA_BROKER: kafka:9092
   notifications:
     build: ./services/notifications
     ports:
       - "3004:3000"
     depends_on:
       - postgres
+      - kafka
+    environment:
+      KAFKA_BROKER: kafka:9092
 volumes:
   pgdata:

--- a/packages/event-bus/package.json
+++ b/packages/event-bus/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@e-commerce/event-bus",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b",
+    "lint": "eslint src --ext .ts"
+  },
+  "dependencies": {
+    "kafkajs": "^2.2.4"
+  }
+}

--- a/packages/event-bus/src/index.ts
+++ b/packages/event-bus/src/index.ts
@@ -1,0 +1,45 @@
+import { Kafka, Consumer, EachMessagePayload } from 'kafkajs';
+
+const broker = process.env.KAFKA_BROKER || 'localhost:9092';
+
+export class KafkaService {
+  private kafka = new Kafka({ clientId: 'e-commerce', brokers: [broker] });
+  private producer = this.kafka.producer();
+  private consumers: Consumer[] = [];
+
+  async emit(topic: string, message: unknown) {
+    await this.producer.connect();
+    await this.producer.send({
+      topic,
+      messages: [{ value: JSON.stringify(message) }],
+    });
+  }
+
+  async subscribe(
+    topic: string,
+    groupId: string,
+    handler: (value: unknown) => Promise<void> | void,
+  ) {
+    const consumer = this.kafka.consumer({ groupId });
+    await consumer.connect();
+    await consumer.subscribe({ topic });
+    await consumer.run({
+      eachMessage: async ({ message }: EachMessagePayload) => {
+        const value = message.value?.toString();
+        if (value) {
+          await handler(JSON.parse(value));
+        }
+      },
+    });
+    this.consumers.push(consumer);
+  }
+
+  async disconnect() {
+    await Promise.all([
+      this.producer.disconnect(),
+      ...this.consumers.map((c) => c.disconnect()),
+    ]);
+  }
+}
+
+export const kafkaService = new KafkaService();

--- a/packages/event-bus/tsconfig.json
+++ b/packages/event-bus/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,10 +68,19 @@ importers:
         specifier: ^4.17.21
         version: 4.17.23
 
+  packages/event-bus:
+    dependencies:
+      kafkajs:
+        specifier: ^2.2.4
+        version: 2.2.4
+
   packages/shared: {}
 
   services/notifications:
     dependencies:
+      '@e-commerce/event-bus':
+        specifier: workspace:*
+        version: link:../../packages/event-bus
       '@nestjs/common':
         specifier: ^10.0.0
         version: 10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2)
@@ -96,6 +105,9 @@ importers:
 
   services/orders:
     dependencies:
+      '@e-commerce/event-bus':
+        specifier: workspace:*
+        version: link:../../packages/event-bus
       '@nestjs/common':
         specifier: ^10.0.0
         version: 10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2)
@@ -988,6 +1000,10 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  kafkajs@2.2.4:
+    resolution: {integrity: sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA==}
+    engines: {node: '>=14.0.0'}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2384,6 +2400,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  kafkajs@2.2.4: {}
 
   keyv@4.5.4:
     dependencies:

--- a/services/notifications/package.json
+++ b/services/notifications/package.json
@@ -14,6 +14,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.0",
     "swagger-ui-express": "^5.0.1",
-    "yup": "^1.7.0"
+    "yup": "^1.7.0",
+    "@e-commerce/event-bus": "workspace:*"
   }
 }

--- a/services/notifications/src/notifications/notifications.service.ts
+++ b/services/notifications/src/notifications/notifications.service.ts
@@ -1,8 +1,15 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, OnModuleInit } from '@nestjs/common';
 import { CreateNotificationDto } from './dto/create-notification.dto';
+import { kafkaService } from '@e-commerce/event-bus';
 
 @Injectable()
-export class NotificationsService {
+export class NotificationsService implements OnModuleInit {
+  async onModuleInit() {
+    await kafkaService.subscribe('order_created', 'notifications', async (order) => {
+      console.log('Sending notification for order', order);
+    });
+  }
+
   create(data: CreateNotificationDto) {
     return { message: 'Notification sent', data };
   }

--- a/services/notifications/tsconfig.json
+++ b/services/notifications/tsconfig.json
@@ -7,6 +7,15 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": ["src"],
-  "references": [{ "path": "../../packages/shared" }]
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../../packages/shared"
+    },
+    {
+      "path": "../../packages/event-bus"
+    }
+  ]
 }

--- a/services/orders/package.json
+++ b/services/orders/package.json
@@ -14,6 +14,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.0",
     "swagger-ui-express": "^5.0.1",
-    "yup": "^1.7.0"
+    "yup": "^1.7.0",
+    "@e-commerce/event-bus": "workspace:*"
   }
 }

--- a/services/orders/src/orders/orders.controller.ts
+++ b/services/orders/src/orders/orders.controller.ts
@@ -11,8 +11,7 @@ export class OrdersController {
 
   @Post()
   @ApiCreatedResponse({ description: 'Order has been created' })
-  create(@Body(new YupValidationPipe(createOrderSchema)) body: CreateOrderDto) {
+  async create(@Body(new YupValidationPipe(createOrderSchema)) body: CreateOrderDto) {
     return this.ordersService.create(body);
   }
 }
-

--- a/services/orders/src/orders/orders.service.ts
+++ b/services/orders/src/orders/orders.service.ts
@@ -1,10 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { CreateOrderDto } from './dto/create-order.dto';
+import { kafkaService } from '@e-commerce/event-bus';
 
 @Injectable()
 export class OrdersService {
-  create(data: CreateOrderDto) {
-    return { ...data, id: Date.now() };
+  async create(data: CreateOrderDto) {
+    const order = { ...data, id: Date.now() };
+    await kafkaService.emit('order_created', order);
+    return order;
   }
 }
-

--- a/services/orders/tsconfig.json
+++ b/services/orders/tsconfig.json
@@ -5,6 +5,15 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"],
-  "references": [{ "path": "../../packages/shared" }]
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../../packages/shared"
+    },
+    {
+      "path": "../../packages/event-bus"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- add event-bus package backed by Kafka
- publish order creation events and consume them for notifications
- provision Kafka and Zookeeper in docker compose

## Testing
- `pnpm test` *(fails: could not resolve workspaces: We detected multiple package managers in your repository: pnpm, npm)*
- `pnpm lint` *(fails: could not resolve workspaces: We detected multiple package managers in your repository: pnpm, npm)*

------
https://chatgpt.com/codex/tasks/task_e_68ada35eed38832cbdc69a5b5c419a3e